### PR TITLE
feat: allow to ignore certain basename regex

### DIFF
--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -60,6 +60,7 @@ class Configuration(object):
         # Allow redirects (enabled by default)
         self.allow_redirects = True
 
+        self.ignored_images_suffix_list = []
         # English is the fallback
         self._language = 'en'
 


### PR DESCRIPTION
```python

config = Config()
    config.ignored_images_suffix_list = ['favicon.ico', '(.*)\.ico']

    article = Article('https://www.reillywood.com/blog/why-nu/', config=config)
    article.download()
    article.parse()

    print(article.images)
    # {'https://d33wubrfki0l68.cloudfront.net/77d3013f91800257b3ca2adfb995ae24e49fff4e/b3086/img/main/headshot.jpg', 'https://d33wubrfki0l68.cloudfront.net/11567b5dd89a3e5b7f97cfeca58b4c67c6ed4c1c/7af24/img/emoji/think.png'}
    print(article.meta_img or article.top_img)
    # https://d33wubrfki0l68.cloudfront.net/77d3013f91800257b3ca2adfb995ae24e49fff4e/b3086/img/main/headshot.jpg

    config = Config()

    article = Article('https://www.reillywood.com/blog/why-nu/', config=config)
    article.download()
    article.parse()

    print(article.images)
    # {'https://www.reillywood.com/favicon.ico', 'https://d33wubrfki0l68.cloudfront.net/77d3013f91800257b3ca2adfb995ae24e49fff4e/b3086/img/main/headshot.jpg', 'https://d33wubrfki0l68.cloudfront.net/11567b5dd89a3e5b7f97cfeca58b4c67c6ed4c1c/7af24/img/emoji/think.png'}
    print(article.meta_img or article.top_img)
    # https://www.reillywood.com/favicon.ico

```