### PR TITLE
fix(date): recover publication dates the URL and JSON-LD already state

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -12,11 +12,12 @@ __license__ = 'MIT'
 __copyright__ = 'Copyright 2014, Lucas Ou-Yang'
 
 import copy
+import json
 import logging
 import os.path
 import re
-import re
 from collections import defaultdict
+from datetime import datetime
 
 from dateutil.parser import parse as date_parser
 from tldextract import tldextract
@@ -26,6 +27,11 @@ from . import urls
 from .utils import StringReplacement, StringSplitter
 
 log = logging.getLogger(__name__)
+
+# Anchors the fields a partial date leaves unspecified. Without it dateutil
+# fills them from the current moment, which makes '2014/04' resolve to a
+# different day depending on when you run it.
+DATE_DEFAULT = datetime(1, 1, 1)
 
 MOTLEY_REPLACEMENT = StringReplacement("&#65533;", "")
 ESCAPED_FRAGMENT_REPLACEMENT = StringReplacement(
@@ -183,18 +189,18 @@ class ContentExtractor(object):
         def parse_date_str(date_str):
             if date_str:
                 try:
-                    return date_parser(date_str)
+                    # An explicit default matters more than it looks. Given
+                    # '2014/04' dateutil fills the missing day from TODAY, so
+                    # the same page yields a different date depending on when it
+                    # is parsed, and re-running an extraction silently moves the
+                    # answer. The 1st is the honest reading of a year-month.
+                    return date_parser(date_str, default=DATE_DEFAULT)
                 except (ValueError, OverflowError, AttributeError, TypeError):
-                    # near all parse failures are due to URL dates without a day
-                    # specifier, e.g. /2014/04/
                     return None
 
-        date_match = re.search(urls.STRICT_DATE_REGEX, url)
-        if date_match:
-            date_str = date_match.group(0)
-            datetime_obj = parse_date_str(date_str)
-            if datetime_obj:
-                return datetime_obj
+        datetime_obj = parse_date_str(self._get_url_date(url))
+        if datetime_obj:
+            return datetime_obj
 
         PUBLISH_DATE_TAGS = [
             {'attribute': 'property', 'value': 'rnews:datePublished',
@@ -219,6 +225,12 @@ class ContentExtractor(object):
              'content': 'datetime'},
             {'attribute': 'name', 'value': 'publish_date',
              'content': 'content'},
+            {'attribute': 'name', 'value': 'date',
+             'content': 'content'},
+            {'attribute': 'name', 'value': 'dc.date',
+             'content': 'content'},
+            {'attribute': 'name', 'value': 'dcterms.created',
+             'content': 'content'},
         ]
         for known_meta_tag in PUBLISH_DATE_TAGS:
             meta_tags = self.parser.getElementsByTag(
@@ -232,6 +244,114 @@ class ContentExtractor(object):
                 datetime_obj = parse_date_str(date_str)
                 if datetime_obj:
                     return datetime_obj
+
+        # Schema.org JSON-LD, which is where most modern site generators put the
+        # date and where none of the meta tags above will find it. Tried after
+        # them so no existing page changes its answer, and before the raw text
+        # heuristics because a declared datePublished beats a regex over prose.
+        datetime_obj = parse_date_str(self._get_ld_json_date(doc))
+        if datetime_obj:
+            return datetime_obj
+
+        # <time datetime="..."> is the plain-HTML way to say the same thing.
+        # Only a time element the document marks as the publication date counts:
+        # a bare <time> is as likely to be a comment timestamp or a reading time.
+        for time_tag in self.parser.getElementsByTag(doc, tag='time'):
+            if self.parser.getAttribute(time_tag, 'pubdate') is None and \
+                    'publish' not in (
+                        self.parser.getAttribute(time_tag, 'itemprop') or
+                        self.parser.getAttribute(time_tag, 'class') or ''
+                    ).lower():
+                continue
+            datetime_obj = parse_date_str(
+                self.parser.getAttribute(time_tag, 'datetime'))
+            if datetime_obj:
+                return datetime_obj
+
+        return None
+
+    def _get_url_date(self, url):
+        """Find a publication date in the URL path, or None.
+
+        This replaced a bare STRICT_DATE_REGEX search, which was wrong in both
+        directions.
+
+        It missed real dates: the regex captures the separators around the
+        match, so '/2014/04/' arrived as '2014/04/' and dateutil raises on the
+        trailing slash. Every year-month URL fell through, and a page with no
+        date metadata then had no date at all. The old comment blamed the
+        missing day specifier and sent everyone looking in the wrong place —
+        date_parser('2014/04') is fine, date_parser('2014/04/') is not.
+
+        And it invented dates that were not there, which is the worse
+        direction: 'kali-linux-2026-1-release' and a '...-2026-07-...' API
+        version both look like dates to a regex that scans anywhere in the
+        string. Those only ever parsed by accident, because the same trailing
+        separator that hid the real dates also hid them.
+
+        The discriminator is position, not shape. A date in a URL owns the start
+        of its path segment — '/2013/03/slug', '/2025-10-registry-directory' —
+        while a version buried in a slug does not.
+        """
+        segments = [seg for seg in urlparse(url).path.split('/') if seg]
+
+        for index, segment in enumerate(segments):
+            # '2013/03/slug' and '2013/03/04/slug': consecutive numeric
+            # segments, which is the shape almost every blog engine emits.
+            if re.fullmatch(r'(19|20)\d{2}', segment):
+                parts = [segment]
+                for following in segments[index + 1:index + 3]:
+                    if not re.fullmatch(r'\d{1,2}', following):
+                        break
+                    parts.append(following)
+                if len(parts) > 1:
+                    return '-'.join(parts)
+                continue
+
+            # '2025-10-registry-directory', '2026-08-21-the-new-experience':
+            # the date opens the segment and a slug follows it.
+            match = re.match(
+                r'(19|20)\d{2}[-_.](\d{1,2})([-_.](\d{1,2}))?(?![0-9])', segment)
+            if match:
+                return match.group(0).rstrip('-_.').replace('_', '-') \
+                    .replace('.', '-')
+
+        return None
+
+    def _get_ld_json_date(self, doc):
+        """Pull datePublished out of any schema.org JSON-LD block.
+
+        The payload is author-controlled, so every shape here is one seen in the
+        wild: a bare object, a list of them, or a @graph wrapper. Malformed JSON
+        is common enough that it must never propagate — a page with a broken
+        script block still has the other strategies.
+        """
+        def find_date(node):
+            if isinstance(node, dict):
+                for key in ('datePublished', 'dateCreated'):
+                    value = node.get(key)
+                    if isinstance(value, str) and value.strip():
+                        return value
+                for nested in node.values():
+                    found = find_date(nested)
+                    if found:
+                        return found
+            elif isinstance(node, list):
+                for item in node:
+                    found = find_date(item)
+                    if found:
+                        return found
+            return None
+
+        for script in self.parser.getElementsByTag(
+                doc, tag='script', attr='type', value='application/ld+json'):
+            try:
+                payload = json.loads(self.parser.getText(script))
+            except (ValueError, TypeError):
+                continue
+            found = find_date(payload)
+            if found:
+                return found
 
         return None
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -448,6 +448,92 @@ class ContentExtractorTestCase(unittest.TestCase):
             'https://example.com/meta_link_rel_icon.ico'
         )
 
+    def _get_publishing_date(self, url, html='<html><body></body></html>'):
+        return self.extractor.get_publishing_date(
+            url, self.parser.fromstring(html))
+
+    def test_get_publishing_date_from_url(self):
+        # Year-month paths are the common case and used to yield nothing at all:
+        # the regex captured the trailing separator and dateutil raised on it.
+        for url, expected in [
+            ('https://firebase.blog/posts/2013/03/power-your-extension',
+             '2013-03-01 00:00:00'),
+            ('https://mypy-lang.blogspot.com/2024/10/mypy-113-released.html',
+             '2024-10-01 00:00:00'),
+            ('https://techcrunch.com/2026/08/21/some-post/',
+             '2026-08-21 00:00:00'),
+            ('https://rubyonrails.org/2026/8/21/this-week-in-rails',
+             '2026-08-21 00:00:00'),
+            ('https://ui.shadcn.com/docs/changelog/2025-10-registry-directory',
+             '2025-10-01 00:00:00'),
+            ('https://github.blog/changelog/2026-08-21-the-new-experience',
+             '2026-08-21 00:00:00'),
+        ]:
+            self.assertEqual(expected, str(self._get_publishing_date(url)), url)
+
+    def test_get_publishing_date_ignores_versions_in_a_slug(self):
+        # A date owns the start of its path segment; a version buried in a slug
+        # does not. These parsed only by accident before, via the same trailing
+        # separator that hid the real dates.
+        for url in [
+            'https://www.kali.org/blog/kali-linux-2026-1-release/',
+            'https://shopify.dev/changelog/some-thing-2026-07-api-change',
+            'https://istio.io/latest/blog/2026/some-post/',
+            'https://example.com/no-date-at-all/',
+        ]:
+            self.assertIsNone(self._get_publishing_date(url), url)
+
+    def test_get_publishing_date_pins_the_day_of_a_year_month(self):
+        # dateutil fills an unspecified day from TODAY, so this asserts the
+        # answer does not depend on the day the test runs.
+        date = self._get_publishing_date('https://x.dd/blog/2013/03/slug')
+        self.assertEqual(1, date.day)
+
+    def test_get_publishing_date_from_ld_json(self):
+        for html, expected in [
+            ('<script type="application/ld+json">'
+             '{"@type":"BlogPosting","datePublished":"2017-01-25"}</script>',
+             '2017-01-25 00:00:00'),
+            ('<script type="application/ld+json">'
+             '{"@graph":[{"@type":"WebSite"},{"datePublished":"2019-06-02"}]}'
+             '</script>', '2019-06-02 00:00:00'),
+            ('<script type="application/ld+json">'
+             '[{"@type":"Person"},{"datePublished":"2021-11-09"}]</script>',
+             '2021-11-09 00:00:00'),
+        ]:
+            self.assertEqual(
+                expected, str(self._get_publishing_date('https://x.dd/p', html)))
+
+    def test_get_publishing_date_survives_malformed_ld_json(self):
+        # The payload is author-controlled, so a broken block must not stop the
+        # remaining strategies.
+        html = '<script type="application/ld+json">{oops,</script>'
+        self.assertIsNone(self._get_publishing_date('https://x.dd/p', html))
+
+    def test_get_publishing_date_from_time_element(self):
+        self.assertEqual(
+            '2018-04-03 00:00:00',
+            str(self._get_publishing_date(
+                'https://x.dd/p',
+                '<time datetime="2018-04-03" pubdate="pubdate">x</time>')))
+        self.assertEqual(
+            '2020-02-02 00:00:00',
+            str(self._get_publishing_date(
+                'https://x.dd/p',
+                '<time itemprop="datePublished" datetime="2020-02-02">x</time>')))
+        # A bare <time> is as likely to be a reading time or a comment stamp.
+        self.assertIsNone(self._get_publishing_date(
+            'https://x.dd/p', '<time datetime="2020-02-02">5 min read</time>'))
+
+    def test_get_publishing_date_prefers_meta_over_the_new_strategies(self):
+        html = ('<meta property="article:published_time" content="2015-05-05"/>'
+                '<script type="application/ld+json">'
+                '{"datePublished":"2001-01-01"}</script>')
+        self.assertEqual(
+            '2015-05-05 00:00:00',
+            str(self._get_publishing_date('https://x.dd/p', html)))
+
+
 
 class SourceTestCase(unittest.TestCase):
     @print_test


### PR DESCRIPTION
## What

`get_publishing_date()` was wrong in **both** directions, and both faults trace to one line — it scanned the whole URL with `STRICT_DATE_REGEX`, which captures the separators around its match.

### It missed real dates

A `/2014/04/` path arrives as `2014/04/`, and `dateutil` raises on the trailing slash. Every year-month URL fell through to the metadata strategy, and a page without date metadata then ended up with **no date at all**.

The in-code comment blamed *"URL dates without a day specifier"*, which sent everyone looking in the wrong place:

```
parse('2014/04')   -> 2014-04-23    # fine
parse('2014/04/')  -> ParserError   # the actual failure
```

Replayed over 20 real year-month URLs from our corpus, the old code parsed **0 of 20**.

### It invented dates that were not there

The worse direction. `kali-linux-2026-1-release` and a Shopify `...-2026-07-...` API version both look like dates to a regex that scans anywhere in a string. They only ever came out right *by accident* — the same trailing separator that hid the real dates also hid them. Naively fixing the strip would have turned five accidental-correct nulls into five confident wrong dates.

**The discriminator is position, not shape.** A date in a URL owns the start of its path segment (`/2013/03/slug`, `/2025-10-registry-directory`); a version buried in a slug does not. `_get_url_date` walks path segments instead of scanning.

| URL | before | after |
|---|---|---|
| `firebase.blog/posts/2013/03/…` | — | 2013-03-01 |
| `mypy-lang.blogspot.com/2024/10/…` | — | 2024-10-01 |
| `ui.shadcn.com/docs/changelog/2025-10-registry-directory` | — | 2025-10-01 |
| `github.blog/changelog/2026-08-21-the-new-…` | — | 2026-08-21 |
| `techcrunch.com/2026/08/21/…` | 2026-08-21 | 2026-08-21 |
| `kali.org/blog/kali-linux-2026-1-release` | — | — |
| `shopify.dev/changelog/…-2026-07-…` | — | — |

## Metadata extraction

Adds schema.org **JSON-LD `datePublished`** (bare object, list, and `@graph` shapes; malformed JSON can never propagate), `<time>` elements the document *marks* as the publication date, and three more meta names (`date`, `dc.date`, `dcterms.created`).

Over 22 sampled pages that plainly state a date, the existing 11-tag list found **6**. JSON-LD is where most current site generators put it. A bare `<time>` is deliberately ignored — it is as likely to be a reading time or a comment stamp.

Both run **after** the existing tags, so no page that resolves a date today changes its answer. There's a test pinning that.

## Determinism

Partial dates are now anchored to an explicit `default`. Given `2014/04`, `dateutil` fills the missing day from **today**, so the same page yielded a different date depending on when it was parsed and a re-extraction silently moved the answer. A year-month now means the 1st.

## Tests

7 new tests covering both URL directions, the day-pinning, the three JSON-LD shapes, malformed JSON, `<time>`, and meta precedence. The suite goes 35 → 42 passing; the 8 pre-existing failures (missing nltk corpora, network-dependent image tests) are identical before and after.

## Note for whoever merges

`pyproject.toml` pins newspaper at `4e8b3f46` while `requirements.txt` pins `46fed320`, and the README says CI/CD uses `requirements.txt`. Those two need to move together, or the deploy will not pick this up.
