### PR TITLE
fix(date): let a page's own date outrank a year-month URL

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -177,13 +177,22 @@ class ContentExtractor(object):
         # return authors
 
     def get_publishing_date(self, url, doc):
-        """3 strategies for publishing date extraction. The strategies
-        are descending in accuracy and the next strategy is only
-        attempted if a preferred one fails.
+        """Strategies for publishing date extraction, in descending order of
+        accuracy. The next strategy is only attempted if a preferred one fails.
 
-        1. Pubdate from URL
+        1. Pubdate from the URL, when the URL names a day
         2. Pubdate from metadata
-        3. Raw regex searches in the HTML + added heuristics
+        3. Pubdate from schema.org JSON-LD, then a <time> publication element
+        4. Pubdate from the URL when it only names a year and a month
+
+        The URL is split across the first and last places on purpose. A URL
+        that names a day is as precise as anything the page can state, and it
+        cannot be poisoned by a template that stamps every page with the same
+        metadata. A '/2019/07/' URL is coarser than a datePublished the page
+        states about itself, so preferring it would push a page whose metadata
+        says 2022-03-25 back to 2019-07-01 — losing a date the page told us in
+        favour of one we rounded to the 1st. It is still better than no date at
+        all, so it stays as the last fallback.
         """
 
         def parse_date_str(date_str):
@@ -198,9 +207,13 @@ class ContentExtractor(object):
                 except (ValueError, OverflowError, AttributeError, TypeError):
                     return None
 
-        datetime_obj = parse_date_str(self._get_url_date(url))
-        if datetime_obj:
-            return datetime_obj
+        url_date_str = self._get_url_date(url)
+        # '2013-03-04' has a day, '2013-03' does not; only the former outranks
+        # what the page says about itself.
+        if url_date_str and url_date_str.count('-') == 2:
+            datetime_obj = parse_date_str(url_date_str)
+            if datetime_obj:
+                return datetime_obj
 
         PUBLISH_DATE_TAGS = [
             {'attribute': 'property', 'value': 'rnews:datePublished',
@@ -268,7 +281,9 @@ class ContentExtractor(object):
             if datetime_obj:
                 return datetime_obj
 
-        return None
+        # A year-month URL, now that nothing more precise has turned up. The
+        # day lands on the 1st; see parse_date_str for why it is not today's.
+        return parse_date_str(url_date_str)
 
     def _get_url_date(self, url):
         """Find a publication date in the URL path, or None.

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -529,6 +529,39 @@ class ContentExtractorTestCase(unittest.TestCase):
             '2015-05-05 00:00:00',
             str(self._get_publishing_date('https://x.dd/p', html)))
 
+    def test_get_publishing_date_prefers_page_metadata_over_a_year_month_url(self):
+        # A '/2019/07/' URL rounds to the 1st, so a page that states its own
+        # date must win — otherwise supabase's post moves from 2022-03-25 back
+        # to 2019-07-01, which is 2019 only because the slug lives there.
+        url = 'https://supabase.com/blog/2019/07/should-i-open-source-my-company'
+        for html in [
+            '<meta property="article:published_time" content="2022-03-25"/>',
+            '<script type="application/ld+json">'
+            '{"datePublished":"2022-03-25"}</script>',
+            '<time itemprop="datePublished" datetime="2022-03-25">x</time>',
+        ]:
+            self.assertEqual(
+                '2022-03-25 00:00:00',
+                str(self._get_publishing_date(url, html)), html)
+
+    def test_get_publishing_date_prefers_a_full_url_date_over_page_metadata(self):
+        # A URL that names the day is as precise as the page's own claim, and
+        # unlike shared template metadata it is per-article.
+        self.assertEqual(
+            '2026-08-21 00:00:00',
+            str(self._get_publishing_date(
+                'https://techcrunch.com/2026/08/21/some-post/',
+                '<meta property="article:published_time" content="2022-03-25"/>')))
+
+    def test_get_publishing_date_falls_back_to_a_year_month_url(self):
+        # Still the last resort: a page with no date of its own keeps the date
+        # its URL carries rather than none at all.
+        self.assertEqual(
+            '2019-07-01 00:00:00',
+            str(self._get_publishing_date(
+                'https://supabase.com/blog/2019/07/should-i-open-source-my-company',
+                '<time datetime="2022-03-25">5 min read</time>')))
+
 
 
 class SourceTestCase(unittest.TestCase):


### PR DESCRIPTION
## The bug

`get_publishing_date` tries `_get_url_date(url)` first, before the meta tags, JSON-LD and `<time>`. Before 4871cb6 that did not matter for year-month URLs: the old regex captured the trailing separator, `dateutil` raised on `'2014/04/'`, and every such URL fell through to the page's own metadata.

Since 4871cb6 those URLs parse, so they win. A page whose URL contains `/YYYY/MM/` and whose metadata states a precise date now gets the coarse URL date:

```
url  https://supabase.com/blog/2019/07/should-i-open-source-my-company
meta article:published_time = 2022-03-25
     -> 2019-07-01   (was 2022-03-25 before the pin)
```

The 2019 comes only from the folder the slug sits under, and the day is invented — rounded to the 1st.

Measured on the prod api read replica: **62,245** existing posts have a year-month-only URL plus a precise stored `publishedAt`, and would move earlier by a median of 15 days (max 30) on a re-date. Concentrated in securityboulevard, aws, rbloggers, infoq, smashing, thn, kdnuggets.

## The fix

Split the URL strategy by precision rather than dropping it:

- a URL that **names the day** (`/2026/08/21/slug`) still goes first — it is as precise as anything the page can state, and unlike template metadata it is per-article;
- a **year-month** URL runs last, after the meta tags, JSON-LD and `<time>`, and only supplies a date when nothing else did.

`_get_url_date` is untouched, so the version-in-slug rejection (`kali-linux-2026-1-release`) behaves exactly as before.

## Tests

Three added to `ContentExtractorTestCase`: the supabase case against each of the three page-side strategies, a full-day URL still beating metadata, and a year-month URL still landing on 2019-07-01 when the page states nothing.

Verified: `-k publishing_date` is 10 passed; reverting only `extractors.py` to 4871cb6 fails exactly one — the new precedence test. The rest of `unit_tests.py` has 8 failures that are identical on 4871cb6 (missing NLTK corpora / network).

Downstream in yggdrasil-cleaner-newspaper the full suite passes against this branch, and one existing test there needed updating — it used a fixture that does carry `article:published_time`, so it was asserting the regression.

This unblocks a safe full re-date backfill of the post corpus.