### PR TITLE
fix(date): read JSON-LD from the raw doc, not the cleaned one

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -280,9 +280,16 @@ class Article(object):
         meta_data = self.extractor.get_meta_data(self.clean_doc)
         self.set_meta_data(meta_data)
 
+        # The RAW doc, not the cleaned one: the document cleaner strips <script>
+        # tags, and schema.org JSON-LD lives in one. Passing clean_doc here meant
+        # the JSON-LD strategy could never fire through this path, silently — the
+        # URL and <meta> strategies still worked, so a page carrying only JSON-LD
+        # came back undated and looked like a page with no date at all. Every
+        # other strategy reads <head>, which the cleaner leaves alone, so the raw
+        # doc is a superset for this purpose.
         self.publish_date = self.extractor.get_publishing_date(
             self.url,
-            self.clean_doc)
+            self.doc)
 
         self.top_node = self.extractor.calculate_best_node(self.doc)
         if self.top_node is None:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -525,6 +525,27 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertIsNone(self._get_publishing_date(
             'https://x.dd/p', '<time datetime="2020-02-02">5 min read</time>'))
 
+    def test_publish_date_from_ld_json_through_a_full_parse(self):
+        # Through Article.parse rather than the extractor directly, because that
+        # is where this broke: parse() used to hand over the CLEANED doc, whose
+        # <script> tags the document cleaner has already removed, so a page
+        # carrying its date only in JSON-LD came back undated. Calling the
+        # extractor with a freshly parsed doc — as every other test here does —
+        # cannot catch that.
+        html = (
+            '<html><head><title>T</title>'
+            '<script type="application/ld+json">'
+            '{"@type":"NewsArticle","datePublished":"2026-02-16T09:00:00-05:00"}'
+            '</script></head><body><article><p>%s</p></article></body></html>'
+        ) % ('Body text long enough to parse as an article. ' * 12)
+
+        article = Article('https://example.com/some-post-with-no-date-in-the-url')
+        article.download(input_html=html)
+        article.parse()
+
+        self.assertIsNotNone(article.publish_date)
+        self.assertEqual('2026-02-16', article.publish_date.strftime('%Y-%m-%d'))
+
     def test_get_publishing_date_prefers_meta_over_the_new_strategies(self):
         html = ('<meta property="article:published_time" content="2015-05-05"/>'
                 '<script type="application/ld+json">'


### PR DESCRIPTION
The JSON-LD strategy added in #12 **could never fire through `Article.parse()`**.

`parse()` handed `get_publishing_date` the **cleaned** document, and the document cleaner's `remove_scripts_styles` has already stripped every `<script>` tag — which is exactly where schema.org JSON-LD lives.

```python
# newspaper/article.py
self.publish_date = self.extractor.get_publishing_date(self.url, self.clean_doc)
                                                                 # ^ scripts already gone
```

## Why this was expensive rather than obvious

It failed **silently**. The URL and `<meta>` strategies still worked, so a page carrying its date only in JSON-LD came back undated — indistinguishable from a page that genuinely states no date anywhere.

Measured on a 300-row production slice of undated posts: **46 dated, 254 reported "page states no date"**. The first one inspected by hand — a laravel-news article — had this sitting in its stored HTML the whole time:

```json
"datePublished": "2026-02-16T09:00:00-05:00"
```

Isolated in the running cleaner pod, which made the cause unambiguous:

```
Article.publish_date                       = None
extractor on clean_doc                     = None
extractor on a fresh parse of the same html = 2026-02-16 09:00:00-05:00
_get_ld_json_date(clean_doc)               = None
_get_ld_json_date(fresh)                   = 2026-02-16T09:00:00-05:00
```

## The fix

Pass `self.doc`. Every other strategy reads `<head>`, which the cleaner leaves alone, so the raw doc is a superset for this purpose — no existing strategy changes behaviour.

## The test gap this closes

**#12's tests could not have caught this.** They all called `get_publishing_date` directly with a freshly parsed doc — precisely the path that works. The test added here goes through `Article.parse()` and fails without the one-line change:

```
--- WITHOUT the fix ---
FAILED tests/unit_tests.py::...::test_publish_date_from_ld_json_through_a_full_parse
--- WITH the fix, against the real stored page ---
publish_date = 2026-02-16 09:00:00-05:00
```

Suite goes 42 → 43 passing; the 8 pre-existing failures (missing nltk corpora, network-dependent image tests, a meta fixture drift) are identical before and after.

## Impact

Unblocks the `published_at` backfill in dailydotdev/yggdrasil#727. The 300-row slice yielded 15% — almost exactly the URL tier alone — because the JSON-LD tier was contributing nothing.