### PR TITLE
fix(date): bring the URL-precedence fix onto master alongside the raw-doc fix

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -177,13 +177,22 @@ class ContentExtractor(object):
         # return authors
 
     def get_publishing_date(self, url, doc):
-        """3 strategies for publishing date extraction. The strategies
-        are descending in accuracy and the next strategy is only
-        attempted if a preferred one fails.
+        """Strategies for publishing date extraction, in descending order of
+        accuracy. The next strategy is only attempted if a preferred one fails.
 
-        1. Pubdate from URL
+        1. Pubdate from the URL, when the URL names a day
         2. Pubdate from metadata
-        3. Raw regex searches in the HTML + added heuristics
+        3. Pubdate from schema.org JSON-LD, then a <time> publication element
+        4. Pubdate from the URL when it only names a year and a month
+
+        The URL is split across the first and last places on purpose. A URL
+        that names a day is as precise as anything the page can state, and it
+        cannot be poisoned by a template that stamps every page with the same
+        metadata. A '/2019/07/' URL is coarser than a datePublished the page
+        states about itself, so preferring it would push a page whose metadata
+        says 2022-03-25 back to 2019-07-01 — losing a date the page told us in
+        favour of one we rounded to the 1st. It is still better than no date at
+        all, so it stays as the last fallback.
         """
 
         def parse_date_str(date_str):
@@ -198,9 +207,13 @@ class ContentExtractor(object):
                 except (ValueError, OverflowError, AttributeError, TypeError):
                     return None
 
-        datetime_obj = parse_date_str(self._get_url_date(url))
-        if datetime_obj:
-            return datetime_obj
+        url_date_str = self._get_url_date(url)
+        # '2013-03-04' has a day, '2013-03' does not; only the former outranks
+        # what the page says about itself.
+        if url_date_str and url_date_str.count('-') == 2:
+            datetime_obj = parse_date_str(url_date_str)
+            if datetime_obj:
+                return datetime_obj
 
         PUBLISH_DATE_TAGS = [
             {'attribute': 'property', 'value': 'rnews:datePublished',
@@ -268,7 +281,9 @@ class ContentExtractor(object):
             if datetime_obj:
                 return datetime_obj
 
-        return None
+        # A year-month URL, now that nothing more precise has turned up. The
+        # day lands on the 1st; see parse_date_str for why it is not today's.
+        return parse_date_str(url_date_str)
 
     def _get_url_date(self, url):
         """Find a publication date in the URL path, or None.

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -554,6 +554,39 @@ class ContentExtractorTestCase(unittest.TestCase):
             '2015-05-05 00:00:00',
             str(self._get_publishing_date('https://x.dd/p', html)))
 
+    def test_get_publishing_date_prefers_page_metadata_over_a_year_month_url(self):
+        # A '/2019/07/' URL rounds to the 1st, so a page that states its own
+        # date must win — otherwise supabase's post moves from 2022-03-25 back
+        # to 2019-07-01, which is 2019 only because the slug lives there.
+        url = 'https://supabase.com/blog/2019/07/should-i-open-source-my-company'
+        for html in [
+            '<meta property="article:published_time" content="2022-03-25"/>',
+            '<script type="application/ld+json">'
+            '{"datePublished":"2022-03-25"}</script>',
+            '<time itemprop="datePublished" datetime="2022-03-25">x</time>',
+        ]:
+            self.assertEqual(
+                '2022-03-25 00:00:00',
+                str(self._get_publishing_date(url, html)), html)
+
+    def test_get_publishing_date_prefers_a_full_url_date_over_page_metadata(self):
+        # A URL that names the day is as precise as the page's own claim, and
+        # unlike shared template metadata it is per-article.
+        self.assertEqual(
+            '2026-08-21 00:00:00',
+            str(self._get_publishing_date(
+                'https://techcrunch.com/2026/08/21/some-post/',
+                '<meta property="article:published_time" content="2022-03-25"/>')))
+
+    def test_get_publishing_date_falls_back_to_a_year_month_url(self):
+        # Still the last resort: a page with no date of its own keeps the date
+        # its URL carries rather than none at all.
+        self.assertEqual(
+            '2019-07-01 00:00:00',
+            str(self._get_publishing_date(
+                'https://supabase.com/blog/2019/07/should-i-open-source-my-company',
+                '<time datetime="2022-03-25">5 min read</time>')))
+
 
 
 class SourceTestCase(unittest.TestCase):


### PR DESCRIPTION
## The problem: two date fixes on divergent lines, and neither branch has both

While answering "do we need to bump the cleaner?", I found the history had forked:

| line | has #12 | has #13 (URL precedence) | has #14 (raw doc) |
|---|---|---|---|
| `master` (`b68d7d3`) | yes | **no** | yes |
| the cleaner's current pin (`bb94ef8`) | yes (as `4871cb6`) | yes | **no** |

#13 was branched from `fix/publishing-date-extraction-on-deployed-pin` rather than `master`, so it never reached `master`:

```
$ git merge-base --is-ancestor 30e5be8 origin/master
NO - master is MISSING #13
```

**So bumping the cleaner straight to `master` would have gained the raw-doc fix and silently regressed the URL-precedence one** — a page whose metadata says `2022-03-25` would go back to `2019-07-01` because a coarse year-month URL outranked it. That is the exact defect #13 was written to fix, and nothing would have failed to tell us.

This cherry-picks #13 onto `master` so one commit has both. No new behaviour.

## Verified combined behaviour

```
1 real stored page, JSON-LD only      -> 2026-02-16 09:00:00-05:00   (#14 working)
2 year-month URL vs page date         -> 2022-03-25                  (#13: page wins)
3 Y/M/D URL vs page date              -> 2019-07-04                  (#13: URL wins)
4 year-month URL, no page date        -> 2019-07-01                  (#13: last fallback)
5 version slug, no page date          -> None                        (#12: still refused)
```

Case 1 is the real production page that exposed #14 — a laravel-news article whose stored HTML carried `"datePublished": "2026-02-16T09:00:00-05:00"` and which came back undated for the entire first dry run.

12 date tests pass, both #13's and #14's included.

## After this merges

The cleaner should be pinned to **this** commit, not to `bb94ef8` or to `master` before it. That bump is next, and then the `published_at` backfill can be re-measured — the 300-row slice yielded 15% with the JSON-LD tier contributing nothing.