### PR TITLE
fix(date): drop generic date meta names, which matched modification stamps

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -215,6 +215,15 @@ class ContentExtractor(object):
             if datetime_obj:
                 return datetime_obj
 
+        # Names here are matched by SUBSTRING, not equality — getElementsByTag
+        # builds an xpath `contains(@name, value)`. That is survivable for the
+        # long, specific names below, and lethal for a short generic one: a
+        # `date` entry matches `name="last-updated"` (up-DATE-d), so a dev.to
+        # article whose JSON-LD says 2021-08-02 came back as its 2024-01-12
+        # modification date. A confidently wrong date is worse than none, so
+        # generic names (`date`, `dc.date`, `dcterms.created`) are deliberately
+        # absent; they would need equality matching to be safe, and JSON-LD
+        # below already covers the pages they were added for.
         PUBLISH_DATE_TAGS = [
             {'attribute': 'property', 'value': 'rnews:datePublished',
              'content': 'content'},
@@ -237,12 +246,6 @@ class ContentExtractor(object):
             {'attribute': 'pubdate', 'value': 'pubdate',
              'content': 'datetime'},
             {'attribute': 'name', 'value': 'publish_date',
-             'content': 'content'},
-            {'attribute': 'name', 'value': 'date',
-             'content': 'content'},
-            {'attribute': 'name', 'value': 'dc.date',
-             'content': 'content'},
-            {'attribute': 'name', 'value': 'dcterms.created',
              'content': 'content'},
         ]
         for known_meta_tag in PUBLISH_DATE_TAGS:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -525,6 +525,26 @@ class ContentExtractorTestCase(unittest.TestCase):
         self.assertIsNone(self._get_publishing_date(
             'https://x.dd/p', '<time datetime="2020-02-02">5 min read</time>'))
 
+    def test_publish_date_ignores_a_modification_date_meta(self):
+        # Meta names are matched by SUBSTRING, so a generic `date` entry matched
+        # `name="last-updated"` (up-DATE-d) and a dev.to article whose JSON-LD
+        # said 2021-08-02 came back as its 2024-01-12 modification date. The
+        # page's own datePublished must win over anything a modification stamp
+        # happens to look like.
+        html = (
+            '<html><head><title>T</title>'
+            '<meta name="last-updated" content="2024-01-12 13:13:27 UTC">'
+            '<script type="application/ld+json">'
+            '{"@type":"Article","datePublished":"2021-08-02T12:38:11Z"}'
+            '</script></head><body><article><p>%s</p></article></body></html>'
+        ) % ('Body text long enough to parse as an article. ' * 12)
+
+        article = Article('https://example.com/no-date-in-this-url')
+        article.download(input_html=html)
+        article.parse()
+
+        self.assertEqual('2021-08-02', article.publish_date.strftime('%Y-%m-%d'))
+
     def test_publish_date_from_ld_json_through_a_full_parse(self):
         # Through Article.parse rather than the extractor directly, because that
         # is where this broke: parse() used to hand over the CLEANED doc, whose


### PR DESCRIPTION
## A confidently wrong date, introduced by #12

Meta names in `PUBLISH_DATE_TAGS` are matched by **substring**, not equality — `getElementsByTag` builds an xpath `contains(@name, value)`.

That is survivable for the long, specific names in the original list. It is lethal for a short generic one: the `date` entry I added in #12 matches **`name="last-updated"`**, because *"up**date**d"* contains *"date"*.

Measured on a real fixture in the cleaner's own suite:

```
dev.to01.html
  JSON-LD  datePublished = 2021-08-02T12:38:11Z   <- the truth
  meta     last-updated  = 2024-01-12 13:13:27 UTC
  result before this PR  = 2024-01-12             <- the modification stamp won
```

The meta strategy runs before JSON-LD, so it never got as far as the correct date. Two other fixtures were right only by accident — they have no modification meta to collide with.

## Why removal rather than reordering

**A confidently wrong date is worse than no date** — that is the premise of the claim ledger this feeds, and a modification stamp is exactly the wrong-date class it exists to prevent. Reordering would leave the trap armed for the next page that carries one.

The three generic names (`date`, `dc.date`, `dcterms.created`) were a speculative addition in #12. They would each need equality matching to be safe (`dc.date` substring-matches `dc.date.modified`), and **JSON-LD — which only actually started running after #14 — already covers the pages they were added for.** So they are removed, with a comment recording the substring semantics so nobody re-adds one.

## Verified

The three cleaner fixtures that this was breaking now all produce their true publication dates:

```
ok   dev.to01.html                  2021-08-02
ok   blog.suhailkakar.com01.html    2021-08-27
ok   www.producthunt.com01.html     2022-04-14
```

13 date tests pass, including a new one that pins a `last-updated` meta losing to a page's `datePublished`. Suite 47 passing; the 8 pre-existing failures (nltk corpora, network image tests, a meta fixture drift) are unchanged.

## Sequence note

This is the third defect found by *running* the backfill rather than by reading the code — after the `gs://` path bug (yggdrasil#728) and the cleaned-doc bug (#14). Each was invisible to the previous layer's tests.